### PR TITLE
style: adjust vertical margins for motivation card image

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -480,6 +480,10 @@ border-radius: 50%;
         column-gap: clamp(30px, 10.42vw, 200px);   /* Адаптивное растояние между элементами по горизонтали */
       }
 
+      .motivation-card-image {
+        margin-block: -60px;
+      }
+
 
       /* # # # # # # # # # # # # #   А   Д   А   П   Т   И   В  # # # # # # # # # # # # #  */
 


### PR DESCRIPTION
- Applied negative margin-block of -60px to the .motivation-card-image class.
- This adjustment allows the image to overlap with the preceding element, enhancing the visual layout.