### PR TITLE
feat: declare utilitarian class .title-medium

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -253,6 +253,9 @@ h6 {
   text-transform: uppercase;
 }
 
+/* Утилитарный класс для повторяющихся на странице заголовков с одинаковыми стилями */
+.title-medium {}
+
 
 .button {
   /* для того, чтобы к кнопке применилось свойство высоты height. */
@@ -487,6 +490,10 @@ border-radius: 50%;
 
       .motivation-card-body {
         padding-left: 35px;
+      }
+
+      .motivation-card-title {
+
       }
 
 


### PR DESCRIPTION
- Created a utilitarian class for <h3> titles that share the same styles across the page.
- This class is intended to be populated with consistent styling properties.
- Added a comment to the empty rule explaining the purpose and intended styles for the '.title-medium' class.