### PR TITLE
Feat: Add CSS rule for .backdrop-title::before pseudo-element

### DIFF
--- a/index.html
+++ b/index.html
@@ -111,7 +111,7 @@
                 <!-- Утилитарный класс title-medium содержит типографические стили для одинаковых по макету заголовков <h3>  -->
                 <!-- Атрибут 'data-title' с помощью которго будут выводиться буквы 'STRONG' позади заголовка, через CSS -->
                 <h3
-                  class="mativation-card-title backdrop-title title-medium"
+                  class="motivation-card-title backdrop-title title-medium"
                   data-title="Strong"
                   >
                   Be you, just stronger!<br/>
@@ -128,7 +128,7 @@
                   <!-- 2. Значение атрибута href, указывает на корень страницы и при нажатии на ссылку
                   будет переходить в начало страницы -->
                   <!-- 3. Класс button стили для кнопок на странице, класс transparent модификатор класса button -->
-                <a class="mativation-card-button button transparent" href="/">
+                <a class="motivation-card-button button transparent" href="/">
                   View more
                 </a>
               </div>

--- a/styles.css
+++ b/styles.css
@@ -262,8 +262,18 @@ h6 {
 
 /* Элемент с утилитарным класс 'backdrop-title' будет отображаться поверх псевдоэлемнтов применимых к нему */
 .backdrop-title {
-  position: relative; /* Без позиционирования свойство 'z-index' не работает */
+  position: relative; /* Без позиционирования свойство 'z-index' не работает, так же необходимо для позиционирования псевдоэлемента */
   z-index: 2; /* Элемент к которому будут добавляться псевдоэлементы будет распологаться поверх их */
+}
+
+.backdrop-title::before {
+  content: '';
+  display: block; /* Делает элемент блочным, предоставляет возможность задавать размеры, без этого элеменет не отобразится */
+  position: absolute; /* Позиционируется относительно родителя .backdrop-title */
+  right: calc(100% + 8px); /* 100% от правого края родителя, + 8px(по макету) выход за рамки родителя, псевдоэлемент окажется слева */
+  width: 26px;
+  aspect-ratio: 1;
+  background: url('./icons/plus.svg') center/contain no-repeat;
 }
 
 
@@ -420,8 +430,8 @@ h6 {
   aspect-ratio: 1;  /* Если ширина и высота равны ипользую свойство aspect-ratio для идеально ровного соответсвия сторон 1 к 1*/
   margin: 0px 20px;
   /* Короткая запись для нижеследующих 4 свойств:
-  background: url(./icons/bold-arrow-down-right.svg) center/contain no-repeat; */
-  background-image: url(./icons/bold-arrow-down-right.svg);
+  background: url('./icons/bold-arrow-down-right.svg') center/contain no-repeat; */
+  background-image: url('./icons/bold-arrow-down-right.svg');
   background-position: center;
   background-size: contain;
   background-repeat: no-repeat;


### PR DESCRIPTION
- Added a pseudo-element in the form of a plus image.
- The image is displayed to the left of <h3> headings in the '.motivation' section.